### PR TITLE
Update platform email

### DIFF
--- a/docs/cedar-tutorial-videos.md
+++ b/docs/cedar-tutorial-videos.md
@@ -21,7 +21,7 @@ Resources of interest mentioned in this video include:
 * [Fresh FAIR Webinar Series Video - Metadata 101](https://www.youtube.com/watch?v=dt1Yhw0cDOo)
 * [Fresh FAIR Webinar Series Video - Metadata 102](https://www.youtube.com/watch?v=RY1_N0-QENY)
 * Other resources: [healdatafair.org/resources/metadata]([healdatafair.org/resources/metadata](https://www.healdatafair.org/resources/metadata))
-* Contact address for help: [heal-support@datacommons.io](mailto:heal-support@datacommons.io)
+* Contact address for help: [heal-support@gen3.org](mailto:heal-support@gen3.org)
 
 You can also view this video on [YouTube](https://www.youtube.com/watch?v=W8tXLShto5s).
 
@@ -34,6 +34,6 @@ This video provides a step-by-step guide for completing the HEAL study-level met
 Resources of interest mentioned in this video include:
 
 * Other metadata resources: [healdatafair.org/resources/metadata](https://www.healdatafair.org/resources/metadata)
-* Contact address for help: [heal-support@datacommons.io](mailto:heal-support@datacommons.io)
+* Contact address for help: [heal-support@gen3.org](mailto:heal-support@gen3.org)
 
 You can also view this video on [YouTube](https://www.youtube.com/watch?v=4sSKAbmMZiA).

--- a/docs/data-availability.md
+++ b/docs/data-availability.md
@@ -10,7 +10,7 @@
 
 * A couple of fields in the Data Availability section should be updated throughout a HEAL study’s life-cycle (i.e. fields that ask "Has data collection/production started?" or "Has data release started?" will change from “not started” to “started” to “finished”).
 * A few fields in the Data Availability section may need to be updated if/as study timelines stray from originally planned timelines (e.g. a study impacted by COVID-related delays may update values initially provided for fields like "Date when first data will be collected/produced" or "Date when first data will be released" if initially planned dates for these milestones are delayed substantially) 
-* To update your study’s metadata <u>after</u> your initial completion of the form, please contact the Platform Help Desk at heal-support@datacommons.io.
+* To update your study’s metadata <u>after</u> your initial completion of the form, you can always return to the form and change values in a field. The platform will be updated with the new information within about 24 hrs.
 
 **Fill out this section of the CEDAR form:**
 

--- a/docs/data.md
+++ b/docs/data.md
@@ -8,7 +8,7 @@
 
 **Extra context:**
 
-* This section ONLY APPLIES to studies answering “Yes” to “Will your study collect or produce data?” in the Data Availability form section. Contact heal-support@datacommons.io for questions or support.
+* This section ONLY APPLIES to studies answering “Yes” to “Will your study collect or produce data?” in the Data Availability form section. Contact heal-support@gen3.org for questions or support.
 * This section has 10 fields; 
     * The first 3 fields apply to your study even if your study is not a human subjects study
     * The final 7 fields apply to your study ONLY if your study is a human subject study

--- a/docs/human-treatment-applicability.md
+++ b/docs/human-treatment-applicability.md
@@ -10,7 +10,7 @@
 
 * This section will apply to your study <u>even if your study is not a human subjects study</u>
 * This section **ONLY APPLIES** to studies that listed their [Study Translational Focus](https://github.com/HEAL/heal-metadata-schemas/blob/main/for-investigators-how-to/study-level-metadata-fields/study-metadata-schema-for-humans.md#:~:text=study_translational_focus%20(string)%3A) as “Treatment of a Condition”. 
-* Studies that are not focused on studying <u>treatment</u> of a human pain or opioid use condition (e.g. studies that are instead focused on studying the condition itself) should skip this section. Contact heal-support@datacommons.io for questions or support.
+* Studies that are not focused on studying <u>treatment</u> of a human pain or opioid use condition (e.g. studies that are instead focused on studying the condition itself) should skip this section. Contact heal-support@gen3.org for questions or support.
 
 **Fill out this section of the CEDAR form:**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # I found my CEDAR form. Now What?
 
-Technical help for navigating the CEDAR form is available under the "CEDAR Hints" section of this site. Reach out at any time with questions or for support at <u>heal-support@datacommons.io</u>
+Technical help for navigating the CEDAR form is available under the "CEDAR Hints" section of this site. Reach out at any time with questions or for support at <u>heal-support@gen3.org</u>
 
 ## Providing team members access to a CEDAR form
 
@@ -46,7 +46,7 @@ Technical help for navigating the CEDAR form is available under the "CEDAR Hints
         * Follow guidance provided on this site to decide if a form section or field does not apply to your study
             * Sections and fields that do not apply to all studies will be clearly marked and will provide guidance to help determine if it applies to your study
         * If a form section or field does not apply to your study, you can safely skip it 
-        * If you have questions about whether a section or field applies or does not apply to your study, please reach out to <u>heal-support@datacommons.io</u>
+        * If you have questions about whether a section or field applies or does not apply to your study, please reach out to <u>heal-support@gen3.org</u>
 * **Complete the CEDAR form as soon as possible following notification of your HEAL award.**        
     * The CEDAR form has been calibrated to include only fields that appropriately knowledgeable study staff should know and be able to fill out as soon as HEAL funding has been awarded 
     * There is **no need to wait for data collection to start** to fill out the CEDAR form 

--- a/docs/meta-data-location.md
+++ b/docs/meta-data-location.md
@@ -19,7 +19,7 @@
 
     > The “NIH Application ID” <u>auto-populates</u> from NIH RePORTER.  
     
-    > If you detect an error in this field, contact heal-support@datacommons.io immediately, and do NOT proceed with filling out the CEDAR form until instructed to. Do NOT edit pre-populated fields. They will NOT save.
+    > If you detect an error in this field, contact heal-support@gen3.org immediately, and do NOT proceed with filling out the CEDAR form until instructed to. Do NOT edit pre-populated fields. They will NOT save.
 
     **How this field will be used**
     > This field will be used to provide a link to all metadata available for your study on NIH RePORTER on your study's Platform study page. This will help the Platform Users who find your study to learn more about your study and decide whether it is of clear interest for their purposes. It may also be used by the Platform for internal indexing purposes.  

--- a/docs/minimal-info.md
+++ b/docs/minimal-info.md
@@ -14,7 +14,7 @@
     **How to answer**
     > The “Study Title or Name” <u>auto-populates</u> from NIH RePORTER. Ensure your study title is correct. 
     
-    > If your study title is incorrect, contact heal-support@datacommons.io immediately, and do NOT proceed with filling out the CEDAR form until instructed to. Do NOT edit pre-populated fields. They will NOT save.
+    > If your study title is incorrect, contact heal-support@gen3.org immediately, and do NOT proceed with filling out the CEDAR form until instructed to. Do NOT edit pre-populated fields. They will NOT save.
 
     **How this field will be used**
     > This field will be available to free text search and discovery tools on the Platform and the text will be human readable in your study's Platform study table entry and on your study's Platform study page. This will make your study more discoverable by Platform Users, and will help the Platform Users who find your study to identify your study and decide whether it is of clear interest for their purposes.    
@@ -23,7 +23,7 @@
      **How to answer**
     > The “Study Description or Abstract” <u>auto-populates</u> with a short summary of your HEAL-funded study that is written by NIH HEAL Initiative staff and published on the [NIH HEAL Initiative Funded Projects website](https://heal.nih.gov/funding/awarded). If a summary of your study written by NIH HEAL Initiative staff is not available, this field will be auto-populated with the text of your study's abstract as it appears on [NIH RePORTER](https://reporter.nih.gov/). Ensure your study description is correct.  
     
-    > If your study description is incorrect, contact heal-support@datacommons.io immediately, and do NOT proceed with filling out the CEDAR form until instructed to. Do NOT edit pre-populated fields. They will NOT save.
+    > If your study description is incorrect, contact heal-support@gen3.org immediately, and do NOT proceed with filling out the CEDAR form until instructed to. Do NOT edit pre-populated fields. They will NOT save.
 
     **How this field will be used**
     > This field will be available to free text search and discovery tools on the Platform and the text will be human readable in your study's Platform study table entry and on your study's Platform study page. This will make your study more discoverable by Platform Users, and will help the Platform Users who find your study to identify your study, learn something about it, and decide whether it is of clear interest for their purposes. 

--- a/docs/study-translational-focus.md
+++ b/docs/study-translational-focus.md
@@ -12,7 +12,7 @@
 * Even when HEAL studies don’t involve human subjects, they generally focus on learning more about a human pain or opioid use condition (**Condition-focused**) or they focus on learning more about a treatment, intervention, or solution for a human pain or opioid use condition (**Treatment-focused**).
 * We expect that many HEAL Platform users will look for studies, study data, and study-generated knowledge from a condition- or treatment-focused perspective; they will either want to find new information about a human pain or opioid use condition, or treatment for a human pain or opioid use condition.
 * Classifying your study in this way (i.e. identifying your study as either Condition- or Treatment-focused) allows Platform users to quickly find the studies, study data, or study-generated knowledge that will get them closer to the information they are looking for.
-* HEAL studies that are NOT Condition- or Treatment-focused (e.g. career development, increasing diversity, developing general study recruitment or consenting procedures, etc.), may skip this section. **Contact heal-support@datacommons.io if you are unsure or need guidance.**
+* HEAL studies that are NOT Condition- or Treatment-focused (e.g. career development, increasing diversity, developing general study recruitment or consenting procedures, etc.), may skip this section. **Contact heal-support@gen3.org if you are unsure or need guidance.**
 
 **Fill out this section of the CEDAR form:**
 

--- a/docs/study-type.md
+++ b/docs/study-type.md
@@ -23,7 +23,7 @@
     * Business Development
     * Epidemiologic Research.
 
-    > If these do not apply, skip the question, or contact heal-support@datacommons.io for questions or support.
+    > If these do not apply, skip the question, or contact heal-support@gen3.org for questions or support.
 
     **How this field will be used**
     > These values will likely be filterable under “Advanced Search” on the HEAL Platform Discovery page, and will allow users to quickly find broad, relevant studies, study data, or study-generated knowledge. **For example:**
@@ -37,7 +37,7 @@
     > This field allows a single answer selection of “Primary Research” or “Secondary Research.”
 
     >> * *Primary Research*: Your study will collect primary data (i.e. measurements to generate data to address the study research question) OR conduct an active experiment.
-    * *Secondary Research*: Your study will NOT collect primary data AND your study will NOT conduct an active experiment. If these do not apply, skip the question, or contact heal-support@datacommons.io for questions or support.
+    * *Secondary Research*: Your study will NOT collect primary data AND your study will NOT conduct an active experiment. If these do not apply, skip the question, or contact heal-support@gen3.org for questions or support.
     
     **How this field will be used**
     > These values will likely be filterable under “Advanced Search” on the HEAL Platform Discovery page, and will allow Platform users to quickly find broad, relevant studies, study data, or study-generated knowledge. **For example:**
@@ -50,9 +50,9 @@
     > This field allows a single answer: “Observational Research” or “Experimental Research.”
 
     >> * *Observational Research*: If your study will NOT conduct an active experiment (e.g. actively or passively collecting measurements without any intervention, or in the context of a naturally occurring intervention - a “natural experiment”), select “Observational Research."
-    * *Experimental Research*: If your study will conduct an active experiment, select “Experimental Research." If these do not apply, skip the question, or contact heal-support@datacommons.io for questions or support.
+    * *Experimental Research*: If your study will conduct an active experiment, select “Experimental Research." If these do not apply, skip the question, or contact heal-support@gen3.org for questions or support.
     
-    > If these do not apply, skip the question, or contact heal-support@datacommons.io for questions or support. 
+    > If these do not apply, skip the question, or contact heal-support@gen3.org for questions or support. 
 
     **How this field will be used**
     > These values will likely be filterable under “Advanced Search” on the HEAL Platform Discovery page, and will allow users to quickly locate broad, relevant studies, study data, or study-generated knowledge.
@@ -74,9 +74,9 @@
     * *Animal studies* treat or observe animals or animal models (e.g. mice, zebrafish, drosophila).
     * *Human cell/tissue/tissue model OR Animal cell/tissue/tissue model* studies treat or observe human or animal cells (primary or cultured).
     * Molecule studies treat or observe molecules (e.g. enzymology, chemical/protein binding or engineering, protein crystallization, etc.).
-    * For *computational studies*, consider your subject of interest (e.g. modeling humans, human interaction, molecules, or molecular interactions). If these do not apply, skip the question, or contact heal-support@datacommons.io for questions or support.
+    * For *computational studies*, consider your subject of interest (e.g. modeling humans, human interaction, molecules, or molecular interactions). If these do not apply, skip the question, or contact heal-support@gen3.org for questions or support.
     
-    > If these do not apply, skip the question, or contact heal-support@datacommons.io for questions or support. 
+    > If these do not apply, skip the question, or contact heal-support@gen3.org for questions or support. 
 
     **How this field will be used**
     > These values will likely be filterable under “Advanced Search'' on the HEAL Platform Discovery page, and will allow users to quickly find broad, relevant studies, study data, or study-generated knowledge. For **example:**
@@ -87,7 +87,7 @@
 
 ??? note "Study Type/Design"
     **How to answer**
-    > This field allows multiple selections. Select all that apply. If these do not apply, skip the question, or contact heal-support@datacommons.io for questions or support.
+    > This field allows multiple selections. Select all that apply. If these do not apply, skip the question, or contact heal-support@gen3.org for questions or support.
     
     **How this field will be used**
     > These values will likely be filterable under “Advanced Search” on the HEAL Platform Discovery page, and will allow users to quickly find broad, relevant studies, study data, or study-generated knowledge.

--- a/docs/update-cedar-form-metadata.md
+++ b/docs/update-cedar-form-metadata.md
@@ -4,5 +4,5 @@
     **You can access your CEDAR form as many times as you want and update any fields you want, until the form is as complete as it can be at the time of Platform registration.**
 
 !!! note
-    **As your study advances to a point at which additional metadata becomes available – such as a new publication or release of study data – we ask that you contact the Platform Help Desk at heal-support@datacommons.io to navigate updating your original study-level metadata.**
+    **As your study advances to a point at which additional metadata becomes available – such as a new publication or release of study data – we ask that you contact the Platform Help Desk at heal-support@gen3.org to navigate updating your original study-level metadata.**
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Cedar
 nav:
     - Return to HEAL Data Platform Documentation: https://heal.github.io/platform-documentation/
-    - Contact HEAL Support: 'mailto:heal-support@datacommons.io'
+    - Contact HEAL Support: 'mailto:heal-support@gen3.org'
     - CEDAR Form Overview:
       - I found my CEDAR form. Now What?: index.md
     - CEDAR Form Sections:


### PR DESCRIPTION
update email from [heal-support@datacommons.io](mailto:heal-support@datacommons.io) to [heal-support@gen3.org](mailto:heal-support@gen3.org)
do not merge until gen3.org emails are active.

Also, for data-availability.md, I removed the reference to the platform email when I updated the instructions to share that users can return to CEDAR forms to update information as needed. 